### PR TITLE
fix(mem): Recalculate chunk size at each iteration

### DIFF
--- a/src/snap_to_bucket/fs_handler.py
+++ b/src/snap_to_bucket/fs_handler.py
@@ -200,9 +200,9 @@ class FsHandler:
         temp_file_obj.seek(0, os.SEEK_END)
         file_length = temp_file_obj.tell()
         temp_file_obj.seek(0, os.SEEK_SET)
-        free_mem = psutil.virtual_memory().available
-        max_chunk = free_mem - self.TEN_MB
         while temp_file_obj.tell() < file_length:
+            free_mem = psutil.virtual_memory().available
+            max_chunk = free_mem - self.TEN_MB
             self.untar_process.stdin.write(temp_file_obj.read(max_chunk))
         temp_file_obj.close()
         os.unlink(tar_location)

--- a/src/snap_to_bucket/s3_handler.py
+++ b/src/snap_to_bucket/s3_handler.py
@@ -224,10 +224,6 @@ class S3Handler:
         tar_read_bytes = 0
         fifty_mb = 50 * (1024 ** 2)
         five_gb = (5 * (1024 ** 3))
-        free_mem = psutil.virtual_memory().available
-        if free_mem > five_gb:
-            free_mem = five_gb
-        max_chunk = free_mem - fifty_mb
         if self.split_size >= size:
             if self.verbose > 1:
                 print("Uploading snapshot as a single file as " +
@@ -247,6 +243,10 @@ class S3Handler:
         parts_info = list()
         print(f"Uploading {key} to {self.bucket} bucket")
         while True:
+            free_mem = psutil.virtual_memory().available
+            if free_mem > five_gb:
+                free_mem = five_gb
+            max_chunk = free_mem - fifty_mb
             if (tar_read_bytes >= self.split_size):
                 self.__complete_upload(key, uploadid, parts_info)
                 partno += 1


### PR DESCRIPTION
Instead of calculating free memory only once before the worker loop, calculate it in each iteration reducing the risk of causing out of memory errors.

Signed-off-by: Gaurav Mishra <mishra.gaurav@siemens.com>
