### PR TITLE
feat(snap): Add creation time to name

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ snap/<snapshot-name>/<snapshot-id>-<creation-time>-<now-time>.tar
 ```
 
 The snaphost name gets spaces ` ` and `/` replaces as `+` and `_` respectively.
-And the date/time is in ISO 8601 format
+And the date/time is in ISO 8601 format.
 
 This section is controlled by `get_key_for_upload()` of `S3Handler`.
 
@@ -186,6 +186,8 @@ This section is controlled by `get_key_for_upload()` of `S3Handler`.
 1. Create a new volume of the desired size in AWS and attach to an instance.
     - You can also check for `x-amz-meta-disc-size` metadata attached to the S3
       object to get the estimated size of unpacked files.
+    - The meta tag `snap-volume-size` also stores the size of volume from which
+      the snapshot was created.
 2. Download the snapshot from S3 to the instance.
     1. If the upload was splitted, all the parts must be combined into one.
         - `cat <downloaded_parts> > <single_huge>.tar`

--- a/README.md
+++ b/README.md
@@ -171,10 +171,11 @@ use delete with caution
 
 The script will store snapshots with following structure in S3:
 ```
-snap/<snapshot-name>/<snapshot-id>-<%Y-%m-%d_%H-%M-%S-%f>.tar
+snap/<snapshot-name>/<snapshot-id>-<creation-time>-<now-time>.tar
 ```
 
 The snaphost name gets spaces ` ` and `/` replaces as `+` and `_` respectively.
+And the date/time is in ISO 8601 format
 
 This section is controlled by `get_key_for_upload()` of `S3Handler`.
 

--- a/src/snap_to_bucket/ec_2_handler.py
+++ b/src/snap_to_bucket/ec_2_handler.py
@@ -96,6 +96,7 @@ class Ec2Handler:
             for snap in response['Snapshots']:
                 snapshot = dict()
                 snapshot['id'] = snap['SnapshotId']
+                snapshot['created'] = snap['StartTime']
                 for tag in snap['Tags']:
                     if tag['Key'].lower() == "name":
                         snapshot['name'] = tag['Value']

--- a/src/snap_to_bucket/ec_2_handler.py
+++ b/src/snap_to_bucket/ec_2_handler.py
@@ -97,6 +97,7 @@ class Ec2Handler:
                 snapshot = dict()
                 snapshot['id'] = snap['SnapshotId']
                 snapshot['created'] = snap['StartTime']
+                snapshot['volumesize'] = snap['VolumeSize']
                 for tag in snap['Tags']:
                     if tag['Key'].lower() == "name":
                         snapshot['name'] = tag['Value']

--- a/src/snap_to_bucket/s3_handler.py
+++ b/src/snap_to_bucket/s3_handler.py
@@ -166,9 +166,11 @@ class S3Handler:
         """
         meta_data = dict()
         content_type = 'application/x-tar'
-        timestr = datetime.now().strftime("%Y-%m-%d_%H-%M-%S-%f")
+        timestr = datetime.now().isoformat(timespec='seconds')
+        created = snapshot['created'].isoformat(timespec='seconds')
         name = snapshot['name'].replace(' ', '+').replace('/', '_')
-        key = f"snap/{name}/{snapshot['id']}-{timestr}"
+        key = f"snap/{name}/{snapshot['id']}-{created}-{timestr}"
+        meta_data["creation-time"] = snapshot['created'].isoformat()
         if partno == -1:
             key = f"{key}.tar"
             if self.gzip:

--- a/src/snap_to_bucket/s3_handler.py
+++ b/src/snap_to_bucket/s3_handler.py
@@ -171,6 +171,7 @@ class S3Handler:
         name = snapshot['name'].replace(' ', '+').replace('/', '_')
         key = f"snap/{name}/{snapshot['id']}-{created}-{timestr}"
         meta_data["creation-time"] = snapshot['created'].isoformat()
+        meta_data["snap-volume-size"] = f"{snapshot['volumesize']} GiB"
         if partno == -1:
             key = f"{key}.tar"
             if self.gzip:


### PR DESCRIPTION
Store snapshot creation time in the object name like `snap/<name>/<id>-<creation>-<now>.tar`

- The same time is stored as "creation-time" meta-tag.
- The size of volume from which the snapshot was created (in GiB) is stored as "snap-volume-size" meta-tag.

Closes #7