### PR TITLE
fix(untar): Use shutil, direct path for single tar

### DIFF
--- a/src/snap_to_bucket/snap_handler.py
+++ b/src/snap_to_bucket/snap_handler.py
@@ -215,7 +215,7 @@ class SnapToBucket:
             if no_of_objects == 1:
                 temp_path = self.__s3handler.download_key(self.__restore_key,
                                                         -1, self.__restore_dir)
-                self.__fshandler.untar(temp_path)
+                self.__fshandler.untar_single_file(temp_path)
             else:
                 for i in range(1, no_of_objects + 1):
                     temp_path = self.__s3handler.download_key(


### PR DESCRIPTION
- Use [shutil.copyfileobj](https://docs.python.org/3/library/shutil.html#shutil.copyfileobj) to copy buffers instead of doing it manually.
  + Good thing is that it is done in a chunked format by shutil, so no issue processing large files.
- In case of single tar, pass the file path directly to tar.