### PR TITLE
fix(s3): Fix upload call

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,10 @@ Since the S3 has a limit on object size, a single split can not be larger than
 
 ```
 usage: snap_to_bucket [-h] [-v] -b BUCKET [--proxy PROXY] [--noproxy NOPROXY]
-                      [-t TAG] [--type {standard,io1,gp2,sc1,st1}]
+                      [-t TAG] [--type {standard,io1,gp2,gp3,sc1,st1}]
                       [--storage-class {STANDARD,REDUCED_REDUNDANCY,STANDARD_IA,ONEZONE_IA,GLACIER,INTELLIGENT_TIERING,DEEP_ARCHIVE}]
                       [-m DIR] [-d] [-s SIZE] [-g] [-r] [-k KEY] [--boot]
+                      [--restore-dir RESTORE_DIR]
 
 snap_to_bucket is a simple tool based on boto3 to move snapshots to S3 buckets
 
@@ -149,12 +150,13 @@ optional arguments:
   --noproxy NOPROXY     comma separated list of domains which do not require
                         proxy
   -t TAG, --tag TAG     tag on snapshots (default: snap-to-bucket)
-  --type {standard,io1,gp2,sc1,st1}
+  --type {standard,io1,gp2,gp3,sc1,st1}
                         volume type (default: gp2)
   --storage-class {STANDARD,REDUCED_REDUNDANCY,STANDARD_IA,ONEZONE_IA,GLACIER,INTELLIGENT_TIERING,DEEP_ARCHIVE}
                         storage class for S3 objects (default: STANDARD)
   -m DIR, --mount DIR   mount point for disks (default: /mnt/snaps)
-  -d, --delete          delete snapshot after transfer (default: False)
+  -d, --delete          delete snapshot after transfer. Use with caution!
+                        (default: False)
   -s SIZE, --split SIZE
                         split tar in chunks no bigger than (allowed suffix
                         b,k,m,g,t) (default: 5t)
@@ -163,8 +165,9 @@ optional arguments:
   -k KEY, --key KEY     key of the snapshot folder to restore (required if
                         restoring)
   --boot                was the snapshot a bootable volume?
-
-use delete with caution
+  --restore-dir RESTORE_DIR
+                        directory to store S3 objects for restoring (default:
+                        /tmp/snap-to-bucket)
 ```
 
 ### Files on S3

--- a/doc-sources/conf.py
+++ b/doc-sources/conf.py
@@ -25,11 +25,11 @@ sys.path.insert(0, os.path.abspath('../src/'))
 # -- Project information -----------------------------------------------------
 
 project = 'snap_to_bucket'
-copyright = '2020, Siemens AG'
+copyright = '2020-2021, Siemens AG'
 author = 'Gaurav Mishra <mishra.gaurav@siemens.com>'
 
 # The full version, including alpha/beta/rc tags
-release = '1.0.0'
+release = '1.0.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc-sources/index.rst
+++ b/doc-sources/index.rst
@@ -96,9 +96,10 @@ Options
 .. code-block::
 
     usage: snap_to_bucket [-h] [-v] -b BUCKET [--proxy PROXY] [--noproxy NOPROXY]
-                          [-t TAG] [--type {standard,io1,gp2,sc1,st1}]
+                          [-t TAG] [--type {standard,io1,gp2,gp3,sc1,st1}]
                           [--storage-class {STANDARD,REDUCED_REDUNDANCY,STANDARD_IA,ONEZONE_IA,GLACIER,INTELLIGENT_TIERING,DEEP_ARCHIVE}]
                           [-m DIR] [-d] [-s SIZE] [-g] [-r] [-k KEY] [--boot]
+                          [--restore-dir RESTORE_DIR]
 
     snap_to_bucket is a simple tool based on boto3 to move snapshots to S3 buckets
 
@@ -111,12 +112,13 @@ Options
       --noproxy NOPROXY     comma separated list of domains which do not require
                             proxy
       -t TAG, --tag TAG     tag on snapshots (default: snap-to-bucket)
-      --type {standard,io1,gp2,sc1,st1}
+      --type {standard,io1,gp2,gp3,sc1,st1}
                             volume type (default: gp2)
       --storage-class {STANDARD,REDUCED_REDUNDANCY,STANDARD_IA,ONEZONE_IA,GLACIER,INTELLIGENT_TIERING,DEEP_ARCHIVE}
                             storage class for S3 objects (default: STANDARD)
       -m DIR, --mount DIR   mount point for disks (default: /mnt/snaps)
-      -d, --delete          delete snapshot after transfer (default: False)
+      -d, --delete          delete snapshot after transfer. Use with caution!
+                            (default: False)
       -s SIZE, --split SIZE
                             split tar in chunks no bigger than (allowed suffix
                             b,k,m,g,t) (default: 5t)
@@ -125,8 +127,9 @@ Options
       -k KEY, --key KEY     key of the snapshot folder to restore (required if
                             restoring)
       --boot                was the snapshot a bootable volume?
-
-    use delete with caution
+      --restore-dir RESTORE_DIR
+                            directory to store S3 objects for restoring (default:
+                            /tmp/snap-to-bucket)
 
 See :ref:`migrate` for steps to migrate the EBS Snapshots to S3.
 
@@ -136,9 +139,9 @@ Files on S3
 ==============
 
 The script will store snapshots with following structure in S3:
-    ``snap/<snapshot-name>/<snapshot-id>-<%Y-%m-%d_%H-%M-%S-%f>.tar``
+    ``snap/<snapshot-name>/<snapshot-id>-<creation-time>-<now-time>.tar``
 
-The snaphost name gets spaces and ``/`` replaces as ``+`` and ``_`` respectively.
+The snaphost name gets spaces and ``/`` replaces as ``+`` and ``_`` respectively. And the date/time is in ISO 8601 format.
 
 This section is controlled by ``get_key_for_upload()`` of ``S3Handler`` class.
 

--- a/doc-sources/recovery.rst
+++ b/doc-sources/recovery.rst
@@ -9,6 +9,8 @@ Manually
 #. Create a new volume of the desired size in AWS and attach to an instance.
     * You can also check for ``x-amz-meta-disc-size`` metadata attached to the S3
       object to get the estimated size of unpacked files.
+    * The meta tag `snap-volume-size` also stores the size of volume from which
+      the snapshot was created.
 
 #. Download the snapshot from S3 to the instance.
 
@@ -74,5 +76,8 @@ example ``snap/<snapshot-name>``. The scipt will handle single file upload and
 split uploads accordingly.
 
 Use ``--boot`` flag if the snapshot to be restored was a bootable volume.
+
+The flag ``--restore-dir=RESTORE_DIR`` can be used to point the directory where
+object from S3 can be downloaded. It defaults to ``/tmp/snap-to-bucket``.
 
 Restore accepts other options ``--type`` and ``-m/--mount``.

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def read(fname):
 
 metadata = dict(
     name="snap_to_bucket",
-    version="1.0.0",
+    version="1.0.1",
     author="Gaurav Mishra",
     author_email="mishra.gaurav@siemens.com",
     description=("Move AWS EBS Snapshots to S3 Buckets"),


### PR DESCRIPTION
* Remove the optional `ContentLength` from [upload_part()](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.upload_part) causing rare connection timeouts.
* Increase the free memory buffer from 5MiB to 500MiB for obvious reasons.
* Fix documentation
* Update version from `1.0.0` to `1.0.1`

Signed-off-by: Gaurav Mishra <mishra.gaurav@siemens.com>